### PR TITLE
docs: governance v1 policy matrix and escalation path

### DIFF
--- a/docs/governance/GOVERNANCE_V1.md
+++ b/docs/governance/GOVERNANCE_V1.md
@@ -1,9 +1,10 @@
 # moltch governance v1
 
 ## governance metadata
-- **version:** v1.0.1
+- **version:** v1.0.2
 - **effective_date:** 2026-03-08
-- **owner:** boilermolt (product/governance/docs)
+- **owner_role:** agent_product_governance
+- **current_owner:** boilermolt
 - **review_cadence:** biweekly
 - **next_review_due:** 2026-03-22
 
@@ -18,9 +19,9 @@ Define a deterministic, human-supervised governance model for agent actions in m
 - **system_policy_engine**: evaluates policy rules before execution.
 
 ## identity and auth source of truth
-- Role identity is derived from the policy registry + mapped GitHub actor identity.
-- Every proposer/approver/executor must resolve to a verified role at decision time.
-- If identity cannot be verified, action state fails closed -> `blocked_needs_human`.
+- Role identity MUST be derived from the policy registry + mapped GitHub actor identity.
+- Every proposer/approver/executor MUST resolve to a verified role at decision time.
+- If identity cannot be verified, action state MUST fail closed -> `blocked_needs_human`.
 
 ## action classes
 - **A0 informational**: read-only, no external side effects.
@@ -30,9 +31,16 @@ Define a deterministic, human-supervised governance model for agent actions in m
 
 ## separation-of-duties rules
 - no self-approval for A1-A3.
-- proposer cannot be approver for A1-A3.
-- for A2/A3, approver cannot be executor unless explicitly approved by human_owner with audit note.
+- proposer MUST NOT be approver for A1-A3.
+- for A2/A3, approver MUST NOT be executor unless explicitly approved by human_owner with audit note.
 - **peer** for A1 means a different non-system actor with a different role than proposer.
+
+## approval windows (default)
+- A1: 24h
+- A2: 12h
+- A3: 4h
+
+Approvals outside these windows are stale and MUST be rejected.
 
 ## approval policy matrix
 
@@ -44,14 +52,15 @@ Define a deterministic, human-supervised governance model for agent actions in m
 | A3 financial/governance-high | any verified agent or human | human_owner (required) + explicit policy pass | system-mediated only, with immutable log |
 
 ## deterministic policy checks (pre-execution)
-1. action class must be explicitly declared.
-2. proposer role must be allowed for class.
-3. required approver(s) must be present and valid.
-4. separation-of-duties checks must pass.
-5. rollback plan is required for A2/A3 and must include owner, ordered steps, and max rollback window.
-6. idempotency key + request hash must be present and unique for non-A0 actions.
-7. approval must be within valid approval window (not stale).
-8. execution record ID must be reserved before dispatch.
+1. action class MUST be explicitly declared.
+2. proposer role MUST be allowed for class.
+3. required approver(s) MUST be present and valid.
+4. separation-of-duties checks MUST pass.
+5. rollback plan is required for A2/A3 and MUST include owner, ordered steps, and max rollback window.
+6. idempotency key + request hash MUST be present and unique for non-A0 actions.
+7. request hash MUST be computed from canonicalized payload.
+8. approval MUST be within valid approval window (not stale).
+9. execution record ID MUST be reserved before dispatch.
 
 If any check fails: action state -> `blocked_needs_human`.
 
@@ -64,7 +73,7 @@ When blocked >15 minutes, post in standard format:
 5. `needs-human`
 
 ## auditable log requirements
-Every A1-A3 action must persist:
+Every A1-A3 action MUST persist:
 - proposer + approver + executor identities
 - action class + policy decision
 - idempotency key + request hash


### PR DESCRIPTION
Closes #1

## Summary
Adds docs/governance/GOVERNANCE_V1.md to define v1 governance policy for moltch:
- actor roles
- action classes (A0-A3)
- propose/approve/execute matrix
- deterministic pre-execution policy checks
- needs-human escalation format
- audit log requirements
- scenario-based validation cases

## Linked issue
- Required: Closes #<issue>
- Closes #1

## Scope
- [x] governance/product docs
- [ ] repo/workflow
- [ ] frontend
- [ ] backend
- [ ] infra/deploy

## Validation
- Commands/checks run:
  - gh issue view 1 --repo BoilerHAUS/moltch
  - scenario walkthrough included in doc (A1/A2/A3)
- Evidence:
  - matrix and scenario outcomes are explicit and deterministic

## Risk + rollback
- Risk impact: low (docs-only), but policy may be too restrictive initially.
- Rollback plan: use time-boxed v1.1-relaxed appendix with explicit expiry + human_owner sign-off.