### PR TITLE
docs(governance): treasury proposal lifecycle and thresholds v1

### DIFF
--- a/docs/governance/TREASURY_PROPOSAL_LIFECYCLE_V1.md
+++ b/docs/governance/TREASURY_PROPOSAL_LIFECYCLE_V1.md
@@ -1,9 +1,10 @@
 # treasury governance v1
 
 ## metadata
-- version: v1.0.0
+- version: v1.0.1
 - owner_role: agent_product_governance
 - review_cadence: biweekly
+- next_review_due: 2026-03-22
 
 ## objective
 Define a deterministic proposal lifecycle for treasury actions: proposal -> review -> approval -> execution log.
@@ -28,6 +29,18 @@ Define a deterministic proposal lifecycle for treasury actions: proposal -> revi
 - **T2** (501 - 5,000): 2 approvals (delegate_human + human_owner)
 - **T3** (> 5,000): human_owner approval + explicit cooldown window (4h) before execution
 
+## tier -> governance class mapping
+- **T1** -> A1/A2 depending on operational impact
+- **T2** -> A2
+- **T3** -> A3
+
+## stale-approval windows by tier
+- **T1**: 24h
+- **T2**: 12h
+- **T3**: 4h
+
+Approvals outside these windows MUST be treated as stale and rejected.
+
 ## status machine
 `draft -> submitted -> under_review -> approved -> queued_execution -> executed`
 
@@ -49,14 +62,27 @@ invalid transitions MUST be rejected by policy engine.
 ## approval rules
 - proposer MUST NOT approve own proposal.
 - approver identity MUST resolve to verified role.
-- stale approvals (outside class window) MUST be rejected.
+- stale approvals MUST be rejected.
 - A3-equivalent proposals MUST preserve immutable audit trail.
+
+## cancellation authority by state
+- `draft`: proposer, delegate_human, human_owner
+- `submitted`: proposer, delegate_human, human_owner
+- `under_review`: delegate_human, human_owner
+- `approved`: human_owner only
+- `queued_execution`: human_owner only (only before dispatch start)
+
+Cancellation MUST include actor + reason and timestamp.
 
 ## expiry + timeout behavior
 - proposal expires at `expires_at_utc` if not approved.
 - expired proposals are immutable except for metadata note append.
-- cancelled proposals require actor + reason.
 - failed execution requires failure_code and retry_decision note.
+
+## failed execution retry policy
+- max retries: 1 automatic retry for transient infra failure.
+- if retry fails, state remains `failed_execution` and MUST NOT re-enter `queued_execution` without fresh approval.
+- manual retry requires explicit re-approval at same tier threshold.
 
 ## execution logging requirements
 For every attempted execution, log:
@@ -67,6 +93,21 @@ For every attempted execution, log:
 - tx/external reference (if any)
 - result (`executed|failed_execution`)
 - timestamp (UTC)
+
+### minimal log schema example
+```json
+{
+  "proposal_id": "tp_20260308_01",
+  "spend_tier": "T2",
+  "proposer": "agent_product_governance",
+  "approvers": ["delegate_human", "human_owner"],
+  "idempotency_key": "treasury-20260308-01",
+  "request_hash": "sha256:...",
+  "policy_decision": "allow",
+  "result": "executed",
+  "ts_utc": "2026-03-08T10:35:00Z"
+}
+```
 
 ## flow validation set
 - approve path: `draft -> submitted -> under_review -> approved -> queued_execution -> executed`


### PR DESCRIPTION
Closes #2

## Summary
Adds docs/governance/TREASURY_PROPOSAL_LIFECYCLE_V1.md with:
- proposal schema
- spend tiers + approval thresholds
- deterministic status machine and allowed transitions
- expiry/cancel/failure behavior
- execution logging requirements
- validation flows

## Risk impact
Low (docs-only).

## Validation
Includes explicit approve/reject/expire/cancel/failure flow validation set.

## Rollback
Revert doc and reopen issue if threshold tuning is needed.