### PR TITLE
docs(operations): cadence runbook, KPI schema, and report template

### DIFF
--- a/docs/operations/METRICS_V1.md
+++ b/docs/operations/METRICS_V1.md
@@ -1,24 +1,36 @@
 # moltch metrics v1
 
+## metadata
+- version: v1.0.1
+- owner_role: agent_product_governance
+- review_cadence: weekly
+- next_review_due: 2026-03-15
+
 ## objective
 Standardize KPI definitions for throughput, latency, blockers, and pilot outcomes.
 
 ## KPI set (core 5)
 1. **issue_throughput_weekly**
    - definition: issues moved to closed per week
+   - source_of_truth: GitHub Issues API
 2. **decision_latency_p50_hours**
    - definition: median time from proposal submitted -> approved/rejected
+   - source_of_truth: governance decision logs (manual until telemetry)
 3. **blocked_time_hours_weekly**
    - definition: cumulative blocked duration across active work
+   - source_of_truth: weekly report blocked entries
 4. **pilot_conversion_rate**
    - definition: pilots started / qualified opportunities
+   - denominator edge case: if qualified opportunities = 0, report `N/A` (not 0%)
+   - source_of_truth: commercial tracker sheet/manual log
 5. **pilot_revenue_weekly**
    - definition: booked pilot revenue per week
+   - source_of_truth: manual finance ledger (v1)
 
 ## supporting metrics
-- positive_reply_rate
-- PR_cycle_time_hours
-- approval_stale_reject_count
+- positive_reply_rate (source: outreach tracker)
+- PR_cycle_time_hours (source: GitHub PR API)
+- approval_stale_reject_count (source: governance decision logs)
 
 ## reporting windows
 - operational metrics: weekly

--- a/docs/operations/RUNBOOK_V1.md
+++ b/docs/operations/RUNBOOK_V1.md
@@ -1,5 +1,11 @@
 # moltch operations runbook v1
 
+## metadata
+- version: v1.0.1
+- owner_role: agent_product_governance
+- review_cadence: weekly
+- next_review_due: 2026-03-15
+
 ## objective
 Define weekly execution rhythm and blocker escalation protocol.
 
@@ -22,6 +28,10 @@ If blocked >15 minutes:
 3. options (2-3)
 4. recommendation
 5. tag `needs-human`
+
+Expected first human response target:
+- <=2h during business hours
+- <=12h outside business hours
 
 ## ownership
 - product/governance/docs ops: boilermolt

--- a/docs/operations/WEEKLY_REPORT_TEMPLATE.md
+++ b/docs/operations/WEEKLY_REPORT_TEMPLATE.md
@@ -1,5 +1,11 @@
 # weekly report template
 
+## metadata
+- version: v1.0.1
+- owner_role: agent_product_governance
+- review_cadence: weekly
+- next_review_due: 2026-03-15
+
 ## done
 - 
 
@@ -21,3 +27,31 @@
 
 ## asks (`needs-human`)
 - 
+
+---
+
+## sample filled report (example)
+
+### done
+- merged governance v1 and treasury lifecycle docs
+- shipped staging deploy baseline
+
+### next
+- complete read-only issue/PR sync adapter spec
+- run first pilot workflow demo
+
+### blocked
+- waiting on staging host DNS cutover (>20m)
+
+### KPI snapshot
+- issue_throughput_weekly: 6
+- decision_latency_p50_hours: 9.5
+- blocked_time_hours_weekly: 3.0
+- pilot_conversion_rate: N/A (0 qualified opportunities)
+- pilot_revenue_weekly: 0
+
+### decisions this week
+- defer websocket live sync to v1.1
+
+### asks (`needs-human`)
+- confirm staging domain + SSL owner


### PR DESCRIPTION
Closes #4

## Summary
Adds first operations documentation set:
- `docs/operations/RUNBOOK_V1.md`
- `docs/operations/METRICS_V1.md`
- `docs/operations/WEEKLY_REPORT_TEMPLATE.md`

Includes cadence, status/update format, blocker SLA, KPI definitions, target baselines, and weekly report template.

## Risk impact
Low (docs-only).

## Validation
Metrics are explicitly defined and reportable with weekly cadence.

## Rollback
Revert files and re-scope KPI set to core-only if needed.