### PR TITLE
docs: docs index + contributing workflow guide

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -25,6 +25,10 @@ Use the repository PR template for format consistency.
 - boilerclaw: technical architecture/deploy/repo
 - tie-breaks: human owner
 
+Ambiguous task default resolution:
+- use issue label + first assignee role as default lane owner
+- escalate only if assignment still conflicts
+
 ## blocker protocol
 If blocked >15 minutes:
 - post blocker
@@ -37,3 +41,8 @@ If blocked >15 minutes:
 - docs changes SHOULD be issue-linked and scoped.
 - policy and operations docs MUST include owner_role, review cadence, and next review date.
 - keep docs concise and executable (decision-usable).
+
+For policy/ops doc PRs, include:
+- changed sections summary
+- downstream docs touched (or explicit `none`)
+- review-date updates when metadata changes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,8 @@ Single navigation hub for product, governance, operations, and contribution docs
 
 ### product
 - v1 boundary and launch gate: `docs/product/PRD_V1_BOUNDARY.md`
+- commercial v1 loop: `docs/product/COMMERCIAL_V1_LOOP.md`
+- outreach copy v1: `docs/product/OUTREACH_COPY_V1.md`
 
 ### governance
 - governance policy v1: `docs/governance/GOVERNANCE_V1.md`
@@ -20,9 +22,21 @@ Single navigation hub for product, governance, operations, and contribution docs
 - metrics schema v1: `docs/operations/METRICS_V1.md`
 - weekly report template: `docs/operations/WEEKLY_REPORT_TEMPLATE.md`
 - staging deploy baseline: `docs/operations/DEPLOY_STAGING.md`
+- staging edge + TLS: `docs/operations/STAGING_EDGE_TLS.md`
+- staging image versioning: `docs/operations/STAGING_IMAGE_VERSIONING.md`
 
 ### contribution
 - contributor guide: `docs/CONTRIBUTING.md`
+
+## doc status
+| doc | owner_role | last_updated | next_review_due |
+|---|---|---|---|
+| `docs/product/PRD_V1_BOUNDARY.md` | agent_product_governance | 2026-03-08 | 2026-03-15 |
+| `docs/governance/GOVERNANCE_V1.md` | agent_product_governance | 2026-03-08 | 2026-03-22 |
+| `docs/governance/TREASURY_PROPOSAL_LIFECYCLE_V1.md` | agent_product_governance | 2026-03-08 | 2026-03-22 |
+| `docs/operations/RUNBOOK_V1.md` | agent_product_governance | 2026-03-08 | 2026-03-15 |
+| `docs/operations/METRICS_V1.md` | agent_product_governance | 2026-03-08 | 2026-03-15 |
+| `docs/operations/WEEKLY_REPORT_TEMPLATE.md` | agent_product_governance | 2026-03-08 | 2026-03-15 |
 
 ## doc ownership and cadence
 - owner_role: agent_product_governance


### PR DESCRIPTION
Closes #16

## Summary
Adds first docs-pack navigation + contribution guidance:
- `docs/README.md` docs index/navigation map
- `docs/CONTRIBUTING.md` issue-first + PR-gated contributor workflow

## Risk impact
Low (docs-only).

## Validation
New contributors can discover core docs and follow required workflow from docs only.

## Rollback
Revert files and fold guidance back into root README if preferred.