### PR TITLE
docs: refresh root README for current baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,62 @@
 # moltch
 
-multi-agent coordination cockpit for `boilerhaus`:
-- real-time agent/human coordination surfaces
-- task linkage to GitHub issues/PRs
-- governed treasury workflow (`proposal -> approval -> execution log`)
+Governance-first coordination cockpit for **boilerhaus** multi-agent execution.
 
-## repo strategy
+## what it is
+moltch is a monorepo that combines:
+- operator cockpit (`apps/web`)
+- orchestration API (`services/api`)
+- policy/governance docs and contracts
+- staging deployment baselines (build-first + immutable-image modes)
 
-moltch starts as a **monorepo** to keep shared contracts, policy logic, and integration code synchronized while the architecture is still evolving.
+## current baseline (v1 buildout)
+Implemented foundations on `main`:
+- web shell scaffold (`apps/web`)
+- API health/readiness scaffold (`services/api`)
+- governance policy docs (`docs/governance/*`)
+- operations docs + templates (`docs/operations/*`)
+- staging deploy docs and compose flows
+- CI baseline + docs quality gate
 
-### planned packages
-- `apps/web` — operator cockpit UI
-- `services/api` — orchestration + policy API
-- `packages/policy-engine` — deterministic approval/risk rules
-- `packages/integrations-github` — issues/pr/discussion sync
-- `packages/audit-log` — append-only event schema + adapters
+## quickstart
+### local web
+```bash
+cd apps/web
+npm start
+# http://localhost:3000
+```
 
-## v1 principles
-- human approval required for treasury execution
-- deterministic policy checks before side effects
-- append-only, replayable action logs
-- issue-first + PR-gated development workflow
+### local api
+```bash
+cd services/api
+npm start
+# http://localhost:8080/health
+```
 
-## next actions
-1. architecture doc + event model
-2. permissions model (roles/capabilities)
-3. treasury proposal state machine
-4. first clickable UI stub
+### staging (build-first)
+```bash
+docker compose --env-file infra/environments/staging/.env.staging -f docker-compose.staging.yml up -d --build
+```
 
+### staging (immutable image refs)
+```bash
+docker compose --env-file infra/environments/staging/.env.staging -f docker-compose.staging.images.yml up -d
+```
 
-## contributor quick links
-- `docs/REPO_STRUCTURE.md`
-- `docs/ARCHITECTURE.md`
+## docs map
+- docs index: `docs/README.md`
+- architecture: `docs/ARCHITECTURE.md`
+- repo structure: `docs/REPO_STRUCTURE.md`
+- governance policy: `docs/governance/GOVERNANCE_V1.md`
+- treasury lifecycle: `docs/governance/TREASURY_PROPOSAL_LIFECYCLE_V1.md`
+- operations runbook: `docs/operations/RUNBOOK_V1.md`
+- staging deploy: `docs/operations/DEPLOY_STAGING.md`
+
+## contribution contract
+All work is:
+- issue-first
+- fork-branch
+- PR-gated to `BoilerHAUS/moltch:main`
+- no direct pushes to `main`
+
+Use `docs/CONTRIBUTING.md` and the PR template.


### PR DESCRIPTION
Closes #42

## Summary
Updates root README to reflect the current repo baseline, quickstart paths, docs map, and contribution contract.

## Risk impact
Low (documentation only).

## Validation
- confirmed referenced docs/files exist
- quickstart commands align with current scaffolded services

## Rollback
Revert README if another structure/versioning format is preferred.