### PR TITLE
docs: style-refresh core docs with new boilermolt writing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,51 @@
 # moltch
 
-multi-agent coordination cockpit for `boilerhaus`:
-- real-time agent/human coordination surfaces
-- task linkage to GitHub issues/PRs
-- governed treasury workflow (`proposal -> approval -> execution log`)
+Governance-first coordination cockpit for **boilerhaus** multi-agent execution.
 
-## repo strategy
+## objective
+Run agent work with clear approvals, visible state, and auditable outcomes.
 
-moltch starts as a **monorepo** to keep shared contracts, policy logic, and integration code synchronized while the architecture is still evolving.
+## current baseline
+- web cockpit shell: `apps/web`
+- API scaffold with health/readiness: `services/api`
+- governance and treasury contracts: `docs/governance/*`
+- operations runbooks and templates: `docs/operations/*`
+- staging deploy modes (build-first + immutable image refs)
+- CI baseline with docs quality checks
 
-### planned packages
-- `apps/web` — operator cockpit UI
-- `services/api` — orchestration + policy API
-- `packages/policy-engine` — deterministic approval/risk rules
-- `packages/integrations-github` — issues/pr/discussion sync
-- `packages/audit-log` — append-only event schema + adapters
+## quickstart
+### web
+```bash
+cd apps/web
+npm start
+```
+Open `http://localhost:3000`.
 
-## v1 principles
-- human approval required for treasury execution
-- deterministic policy checks before side effects
-- append-only, replayable action logs
-- issue-first + PR-gated development workflow
+### api
+```bash
+cd services/api
+npm start
+```
+Check `http://localhost:8080/health`.
 
-## next actions
-1. architecture doc + event model
-2. permissions model (roles/capabilities)
-3. treasury proposal state machine
-4. first clickable UI stub
+### staging (build-first)
+```bash
+docker compose --env-file infra/environments/staging/.env.staging -f docker-compose.staging.yml up -d --build
+```
 
+### staging (immutable refs)
+```bash
+docker compose --env-file infra/environments/staging/.env.staging -f docker-compose.staging.images.yml up -d
+```
 
-## contributor quick links
-- `docs/REPO_STRUCTURE.md`
-- `docs/ARCHITECTURE.md`
+## docs map
+- docs index: `docs/README.md`
+- architecture: `docs/ARCHITECTURE.md`
+- repo structure: `docs/REPO_STRUCTURE.md`
+- contribution workflow: `docs/CONTRIBUTING.md`
+
+## contribution contract
+- issue-first
+- fork branch
+- PR-gated to `BoilerHAUS/moltch:main`
+- no direct pushes to `main`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,24 +1,35 @@
-# architecture (v1 draft)
+# architecture (v1)
 
-## goal
-provide a control plane where human + agent actors coordinate work and governed treasury actions with full auditability.
+## metadata
+- version: v1.0.1
+- owner_role: agent_technical_delivery
+- review_cadence: biweekly
+- next_review_due: 2026-03-22
+
+## objective
+Provide a control plane where human and agent actors coordinate work and governed treasury actions with full auditability.
 
 ## core flow
-1. event ingested (chat/task/treasury intent)
-2. policy engine evaluates action permissions + required approvals
-3. if approval needed, action enters pending state
-4. once approved, executor performs side effect
-5. action + evidence appended to immutable audit log
+1. ingest event (chat/task/treasury intent)
+2. evaluate policy (permissions + approval requirements)
+3. hold in pending state when approval is required
+4. execute side effect after policy pass and approvals
+5. append action + evidence to immutable log
 
 ## stateful domains
 - coordination threads
-- task board / issue links
+- issue/PR-linked tasks
 - treasury proposals
 - approvals
 - execution outcomes
 
 ## security baseline
 - role-based access control
-- explicit approval thresholds for treasury
+- explicit approval thresholds for treasury actions
 - tamper-evident audit records
 - no silent side effects
+
+## validation focus
+- every side effect has a linked decision record
+- denied actions fail closed with explicit reason
+- approval and execution identities are traceable

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -1,7 +1,13 @@
 # branch protection checklist (main)
 
-apply these settings on `main`:
+## metadata
+- version: v1.0.1
+- owner_role: agent_technical_delivery
+- review_cadence: biweekly
+- next_review_due: 2026-03-22
 
+## required settings
+Apply these protections to `main`:
 - require pull request before merge
 - require at least 1 approval
 - require code owner review
@@ -10,6 +16,6 @@ apply these settings on `main`:
 - disallow force pushes
 - disallow branch deletion
 
-## policy
+## workflow policy
 - no direct pushes to `main`
-- all work issue-first, fork-branch, PR-gated
+- all work is issue-first, fork-branch, PR-gated

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,48 +1,56 @@
 # contributing to moltch
 
-## required workflow
-All work MUST follow issue-first, fork-branch, PR-gated execution.
+## objective
+Keep collaboration predictable, reviewable, and safe.
 
+## required workflow
 1. start from an open issue
 2. create a branch in your fork (`<actor>/issue-<id>-<slug>`)
 3. open PR to `BoilerHAUS/moltch:main`
 4. include `Closes #<issue>` in PR body
-5. wait for required review + checks
-6. merge via PR only (no direct push to `main`)
+5. wait for required review and checks
+6. merge through PR only (no direct push to `main`)
 
 ## PR quality bar
-PR description MUST include:
+Every PR must include:
 - summary
 - linked issue
 - validation evidence
 - risk impact
 - rollback plan
 
-Use the repository PR template for format consistency.
+Use the repository PR template.
 
-## role lanes
+## lane ownership
 - boilermolt: product/governance/commercial/docs
 - boilerclaw: technical architecture/deploy/repo
-- tie-breaks: human owner
+- tie-break: human owner
 
-Ambiguous task default resolution:
-- use issue label + first assignee role as default lane owner
-- escalate only if assignment still conflicts
+Ambiguous task rule:
+- default lane owner = issue label + first assignee role
+- escalate only if conflict remains
 
 ## blocker protocol
 If blocked >15 minutes:
 - post blocker
 - show attempts
-- offer 2-3 options
+- provide 2-3 options
 - recommend one
 - tag `needs-human`
 
-## docs expectations
-- docs changes SHOULD be issue-linked and scoped.
-- policy and operations docs MUST include owner_role, review cadence, and next review date.
-- keep docs concise and executable (decision-usable).
+## docs requirements
+- doc changes should be issue-linked and scoped
+- governance/product/operations docs must include metadata:
+  - `version`
+  - `owner_role`
+  - `review_cadence`
+  - `next_review_due`
+- run docs quality gate before PR:
+```bash
+./scripts/docs/check_docs.sh
+```
 
-For policy/ops doc PRs, include:
+For policy/ops/product doc PRs, include:
 - changed sections summary
-- downstream docs touched (or explicit `none`)
-- review-date updates when metadata changes.
+- downstream docs touched (or `none`)
+- review-date updates when metadata changes

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,23 +1,24 @@
 # moltch docs index
 
-## purpose
-Single navigation hub for product, governance, operations, and contribution docs.
+## objective
+Provide one navigation hub for product, governance, operations, and contribution docs.
 
-## navigation map
+## core docs
 - architecture: `docs/ARCHITECTURE.md`
 - repo structure: `docs/REPO_STRUCTURE.md`
 - branch protection: `docs/BRANCH_PROTECTION.md`
+- contribution workflow: `docs/CONTRIBUTING.md`
 
-### product
+## product docs
 - v1 boundary and launch gate: `docs/product/PRD_V1_BOUNDARY.md`
 - commercial v1 loop: `docs/product/COMMERCIAL_V1_LOOP.md`
 - outreach copy v1: `docs/product/OUTREACH_COPY_V1.md`
 
-### governance
+## governance docs
 - governance policy v1: `docs/governance/GOVERNANCE_V1.md`
 - treasury lifecycle v1: `docs/governance/TREASURY_PROPOSAL_LIFECYCLE_V1.md`
 
-### operations
+## operations docs
 - runbook v1: `docs/operations/RUNBOOK_V1.md`
 - metrics schema v1: `docs/operations/METRICS_V1.md`
 - weekly report template: `docs/operations/WEEKLY_REPORT_TEMPLATE.md`
@@ -25,20 +26,15 @@ Single navigation hub for product, governance, operations, and contribution docs
 - staging edge + TLS: `docs/operations/STAGING_EDGE_TLS.md`
 - staging image versioning: `docs/operations/STAGING_IMAGE_VERSIONING.md`
 
-### contribution
-- contributor guide: `docs/CONTRIBUTING.md`
+## doc status snapshot
+| doc | owner_role | next_review_due |
+|---|---|---|
+| `docs/product/PRD_V1_BOUNDARY.md` | agent_product_governance | 2026-03-15 |
+| `docs/governance/GOVERNANCE_V1.md` | agent_product_governance | 2026-03-22 |
+| `docs/governance/TREASURY_PROPOSAL_LIFECYCLE_V1.md` | agent_product_governance | 2026-03-22 |
+| `docs/operations/RUNBOOK_V1.md` | agent_product_governance | 2026-03-15 |
+| `docs/operations/METRICS_V1.md` | agent_product_governance | 2026-03-15 |
+| `docs/operations/WEEKLY_REPORT_TEMPLATE.md` | agent_product_governance | 2026-03-15 |
 
-## doc status
-| doc | owner_role | last_updated | next_review_due |
-|---|---|---|---|
-| `docs/product/PRD_V1_BOUNDARY.md` | agent_product_governance | 2026-03-08 | 2026-03-15 |
-| `docs/governance/GOVERNANCE_V1.md` | agent_product_governance | 2026-03-08 | 2026-03-22 |
-| `docs/governance/TREASURY_PROPOSAL_LIFECYCLE_V1.md` | agent_product_governance | 2026-03-08 | 2026-03-22 |
-| `docs/operations/RUNBOOK_V1.md` | agent_product_governance | 2026-03-08 | 2026-03-15 |
-| `docs/operations/METRICS_V1.md` | agent_product_governance | 2026-03-08 | 2026-03-15 |
-| `docs/operations/WEEKLY_REPORT_TEMPLATE.md` | agent_product_governance | 2026-03-08 | 2026-03-15 |
-
-## doc ownership and cadence
-- owner_role: agent_product_governance
-- review_cadence: weekly
-- next_review_due: 2026-03-15
+## maintenance rule
+Update this index when you add, rename, or retire core docs.

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -1,27 +1,35 @@
 # repo structure (v1)
 
+## metadata
+- version: v1.0.1
+- owner_role: agent_technical_delivery
+- review_cadence: biweekly
+- next_review_due: 2026-03-22
+
+## objective
+Keep execution lanes clear while architecture is still evolving.
+
 ## layout
 - `apps/` user-facing applications
   - `apps/web` cockpit frontend
 - `services/` deployable backend services
-  - `services/api` policy/orchestration API
+  - `services/api` orchestration and policy API
 - `packages/` shared libraries/contracts
   - `packages/policy-engine`
   - `packages/integrations-github`
   - `packages/audit-log`
-- `infra/` deployment environments and IaC artifacts
+- `infra/` deployment environments and infrastructure artifacts
   - `infra/environments/staging`
-- `docs/` design, governance, operations
+- `docs/` product, governance, and operations docs
   - `docs/product`
   - `docs/governance`
   - `docs/operations`
-- `scripts/` repo automation and helper scripts
+- `scripts/` automation and helper scripts
 
-## ownership lanes
-- technical delivery + deploy: boilerclaw lead
-- product/governance/commercial: boilermolt lead
-- all execution remains issue-first + PR-gated
+## lane ownership
+- technical delivery and deploy: boilerclaw lead
+- product/governance/commercial/docs: boilermolt lead
+- all execution: issue-first and PR-gated
 
-## bootstrap convention
-until runtime stack is finalized, keep scaffolds minimal and language-agnostic.
-follow-up issues will introduce toolchain (`pnpm`/workspace config), app runtime, and CI checks.
+## convention
+Keep scaffolds minimal until runtime/toolchain choices are finalized.


### PR DESCRIPTION
Closes #51

## Summary
Applies the new boilermolt documentation style to core published docs:
- root README
- docs/README
- docs/CONTRIBUTING
- docs/ARCHITECTURE
- docs/REPO_STRUCTURE
- docs/BRANCH_PROTECTION

## What changed
- clearer objectives and scannable structure
- more direct execution language
- standardized workflow/ownership wording
- tightened quickstart and doc navigation clarity

## Risk impact
Low (documentation edits only).

## Validation
Reviewed references for existing files/paths and retained current repo contract language.

## Rollback
Revert commit if style direction needs further adjustment.