### PR TITLE
feat(api): github sync adapter v1 (single repo, read-only)

### DIFF
--- a/services/api/README.md
+++ b/services/api/README.md
@@ -10,9 +10,24 @@ npm start
 Endpoints:
 - `GET /health` -> 200
 - `GET /ready` -> 200 in non-prod, or when `READY_TOKEN` is set
+- `GET /sync/github` -> normalized open issues/PRs for one configured repo
+
+`/sync/github` payload fields:
+- `ok`
+- `repo`
+- `fetched_at`
+- `items[]` with: `id`, `type` (`issue|pr`), `title`, `state`, `url`, `updated_at`, `assignee`
+
+Failure object:
+- `error.kind` in `auth|rate_limit|network`
+- `error.message`
+- `error.status`
 
 Config:
 - `PORT` (default `8080`)
 - `NODE_ENV` (default `development`)
 - `APP_NAME` (default `moltch-api`)
 - `READY_TOKEN` (required for readiness in production)
+- `GITHUB_SYNC_REPO` (default `BoilerHAUS/moltch`, format `owner/repo`)
+- `GITHUB_SYNC_PER_PAGE` (default `25`, range `1..100`)
+- `GITHUB_TOKEN` (optional; recommended to avoid strict anonymous limits)

--- a/services/api/config.js
+++ b/services/api/config.js
@@ -3,11 +3,22 @@ function loadConfig() {
     port: Number(process.env.PORT || 8080),
     nodeEnv: process.env.NODE_ENV || 'development',
     appName: process.env.APP_NAME || 'moltch-api',
-    readyToken: process.env.READY_TOKEN || ''
+    readyToken: process.env.READY_TOKEN || '',
+    githubSyncRepo: process.env.GITHUB_SYNC_REPO || 'BoilerHAUS/moltch',
+    githubSyncPerPage: Number(process.env.GITHUB_SYNC_PER_PAGE || 25),
+    githubToken: process.env.GITHUB_TOKEN || ''
   };
 
   if (!Number.isInteger(cfg.port) || cfg.port < 1 || cfg.port > 65535) {
     throw new Error('Invalid PORT; must be integer in range 1..65535');
+  }
+
+  if (!Number.isInteger(cfg.githubSyncPerPage) || cfg.githubSyncPerPage < 1 || cfg.githubSyncPerPage > 100) {
+    throw new Error('Invalid GITHUB_SYNC_PER_PAGE; must be integer in range 1..100');
+  }
+
+  if (!/^[^/]+\/[^/]+$/.test(cfg.githubSyncRepo)) {
+    throw new Error('Invalid GITHUB_SYNC_REPO; must be owner/repo');
   }
 
   return cfg;

--- a/services/api/githubSync.js
+++ b/services/api/githubSync.js
@@ -1,0 +1,95 @@
+const https = require('https');
+
+function githubRequest(path, token) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      {
+        hostname: 'api.github.com',
+        path,
+        method: 'GET',
+        headers: {
+          'User-Agent': 'moltch-api',
+          Accept: 'application/vnd.github+json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {})
+        },
+        timeout: 8000
+      },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+        res.on('end', () => {
+          resolve({ status: res.statusCode || 0, body });
+        });
+      }
+    );
+
+    req.on('error', (err) => reject(err));
+    req.on('timeout', () => req.destroy(new Error('network_timeout')));
+    req.end();
+  });
+}
+
+function normalizeItem(item) {
+  const isPr = Boolean(item.pull_request);
+  return {
+    id: item.number,
+    type: isPr ? 'pr' : 'issue',
+    title: item.title,
+    state: item.state,
+    url: item.html_url,
+    updated_at: item.updated_at,
+    assignee: item.assignee ? item.assignee.login : null
+  };
+}
+
+async function fetchGithubSync(cfg) {
+  const [owner, repo] = cfg.githubSyncRepo.split('/');
+  const path = `/repos/${owner}/${repo}/issues?state=open&per_page=${cfg.githubSyncPerPage}`;
+
+  try {
+    const response = await githubRequest(path, cfg.githubToken);
+
+    if (response.status === 401 || response.status === 403) {
+      return {
+        ok: false,
+        error: {
+          kind: response.status === 401 ? 'auth' : 'rate_limit',
+          message: 'GitHub API authorization/rate limit failure',
+          status: response.status
+        }
+      };
+    }
+
+    if (response.status >= 400) {
+      return {
+        ok: false,
+        error: {
+          kind: 'network',
+          message: `GitHub API returned status ${response.status}`,
+          status: response.status
+        }
+      };
+    }
+
+    const parsed = JSON.parse(response.body);
+    return {
+      ok: true,
+      repo: cfg.githubSyncRepo,
+      fetched_at: new Date().toISOString(),
+      items: parsed.map(normalizeItem)
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        kind: 'network',
+        message: err.message,
+        status: 0
+      }
+    };
+  }
+}
+
+module.exports = { fetchGithubSync };

--- a/services/api/server.js
+++ b/services/api/server.js
@@ -1,6 +1,7 @@
 const http = require('http');
 const { loadConfig } = require('./config');
 const { log } = require('./logger');
+const { fetchGithubSync } = require('./githubSync');
 
 let cfg;
 try {
@@ -19,12 +20,12 @@ function sendJson(req, res, status, payload) {
   res.end(JSON.stringify(payload));
 }
 
-const server = http.createServer((req, res) => {
+const server = http.createServer(async (req, res) => {
   const start = Date.now();
   const host = req.headers.host || 'localhost';
   const pathname = new URL(req.url, `http://${host}`).pathname;
 
-  if (pathname === '/health' || pathname === '/ready') {
+  if (pathname === '/health' || pathname === '/ready' || pathname === '/sync/github') {
     if (req.method !== 'GET' && req.method !== 'HEAD') {
       sendJson(req, res, 405, { error: 'method_not_allowed' });
       log('info', 'request', { method: req.method, path: pathname, status: res.statusCode, ms: Date.now() - start });
@@ -37,6 +38,19 @@ const server = http.createServer((req, res) => {
   } else if (pathname === '/ready') {
     const ready = Boolean(cfg.readyToken || cfg.nodeEnv !== 'production');
     sendJson(req, res, ready ? 200 : 503, { status: ready ? 'ready' : 'not_ready', requires: ready ? null : 'READY_TOKEN' });
+  } else if (pathname === '/sync/github') {
+    const sync = await fetchGithubSync(cfg);
+    if (!sync.ok) {
+      sendJson(req, res, 502, {
+        ok: false,
+        repo: cfg.githubSyncRepo,
+        fetched_at: new Date().toISOString(),
+        items: [],
+        error: sync.error
+      });
+    } else {
+      sendJson(req, res, 200, sync);
+    }
   } else {
     sendJson(req, res, 404, { error: 'not_found' });
   }


### PR DESCRIPTION
Closes #34

## Summary
Implements smallest shippable read-only GitHub sync slice:
- new `GET /sync/github` endpoint
- single configured repo only (`GITHUB_SYNC_REPO`)
- deterministic normalized payload fields:
  - `id, type, title, state, url, updated_at, assignee` (+ `fetched_at`)
- explicit failure object for auth/rate-limit/network cases
- setup/troubleshooting notes in API README

## Notes
- intentionally avoids multi-repo support and caching in this pass
- uses GitHub REST API directly with optional `GITHUB_TOKEN`

## Validation
- local run verified endpoint returns normalized open issue/PR payload for `BoilerHAUS/moltch`
- config validation added for repo format and page size bounds

## Rollback
Revert this PR; no cross-service migration required.
