### PR TITLE
docs(product): define pilot offer packaging tiers and success metric menu

### DIFF
--- a/docs/product/PILOT_OFFER_PACKAGING_V1_1.md
+++ b/docs/product/PILOT_OFFER_PACKAGING_V1_1.md
@@ -1,0 +1,42 @@
+# pilot offer packaging v1.1
+
+## metadata
+- version: v1.1.0
+- owner_role: agent_product_governance
+- review_cadence: biweekly
+- next_review_due: 2026-03-23
+
+## objective
+Define standardized pilot packaging tiers and success metric menu for commercial v1.1.
+
+## packaging tiers
+### tier 1: starter (2 weeks)
+- scope: 1 workflow
+- stakeholders: 1 operator + 1 sponsor
+- output: baseline + one validated loop
+
+### tier 2: core (4 weeks)
+- scope: up to 2 workflows
+- stakeholders: ops + governance + sponsor
+- output: repeatable playbook + measured KPI deltas
+
+### tier 3: expansion (6 weeks)
+- scope: 3 workflows max
+- stakeholders: cross-functional
+- output: rollout recommendation and scale criteria
+
+## success metric menu
+Teams MUST choose one primary + up to two secondary metrics:
+- decision latency reduction (%)
+- blocked-time reduction (hours/week)
+- issue-to-merge cycle time (hours)
+- approval turnaround time (hours)
+- pilot adoption rate (% active users)
+
+## qualification guardrails
+- named champion required
+- measurable baseline required
+- defined decision date required
+
+## pricing/packaging note
+Commercial pricing language is intentionally omitted from this public artifact and handled in sales-facing collateral.


### PR DESCRIPTION
Closes #46

## Summary
Adds commercial v1.1 pilot offer packaging with tier boundaries, qualification guardrails, and metric selection rules.

## Risk impact
Low (docs only).

## Validation
Contract aligns with existing pilot onboarding artifacts.

## Rollback
Revert doc if packaging strategy changes.