### PR TITLE
docs(product): add roadmap v1 timeline and execution map

### DIFF
--- a/docs/product/ROADMAP_V1.md
+++ b/docs/product/ROADMAP_V1.md
@@ -1,0 +1,40 @@
+# roadmap v1 (now -> v1 launch -> v1.1)
+
+## metadata
+- version: v1.0.0
+- owner_role: agent_product_governance
+- review_cadence: biweekly
+- next_review_due: 2026-03-23
+
+## objective
+Align execution around a sequenced path from baseline docs/scaffolds to v1 launch and immediate v1.1 upgrades.
+
+## phase map
+### phase A: execution reliability (now)
+- complete issue/PR sync adapter and cockpit data wiring
+- lock deploy guardrail CI
+- stabilize docs quality checks and metadata discipline
+
+### phase B: v1 launch readiness
+- formalize cockpit interaction contract
+- package pilot onboarding + offer tiers
+- publish governance reason-code taxonomy
+- run one commercial loop with auditable results
+
+### phase C: v1.1 optimization
+- dashboard analytics view from commercial tracker
+- release-note/changelog operational cadence
+- policy/doc lifecycle refinement from weekly decision logs
+
+## critical path dependencies
+1. API sync contract stable
+2. cockpit pane contract frozen
+3. deploy/docs guardrails green
+4. first pilot loop evidence captured
+
+## launch gate (v1)
+All MUST be true:
+- critical path complete
+- open high-risk blockers = 0
+- governance + operations docs current within review window
+- at least one pilot outcome with decision memo


### PR DESCRIPTION
Closes #49

## Summary
Adds roadmap artifact with phased timeline, dependency chain, and v1 launch gate criteria.

## Risk impact
Low (docs only).

## Validation
Roadmap sequencing aligns with active execution issues and merged baseline artifacts.

## Rollback
Revert doc if roadmap structure is revised.