### PR TITLE
feat: lock three-pane interaction contract + executable checks (issue #64)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "moltch cockpit shell",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test:contract": "node tests/pane-contract.test.js"
   }
 }

--- a/apps/web/paneContract.js
+++ b/apps/web/paneContract.js
@@ -1,0 +1,60 @@
+const PANE_STATES = Object.freeze({
+  LOADING: 'loading',
+  DATA: 'data',
+  EMPTY: 'empty',
+  ERROR: 'error'
+});
+
+const TREASURY_STATES = Object.freeze([
+  'submitted',
+  'under_review',
+  'approved',
+  'executed',
+  'failed'
+]);
+
+const ALLOWED_TREASURY_TRANSITIONS = Object.freeze({
+  submitted: ['under_review', 'failed'],
+  under_review: ['approved', 'failed'],
+  approved: ['executed', 'failed'],
+  executed: [],
+  failed: []
+});
+
+function resolvePaneState({ loading = false, error = null, items = null } = {}) {
+  if (loading) return PANE_STATES.LOADING;
+  if (error) return PANE_STATES.ERROR;
+  if (!Array.isArray(items) || items.length === 0) return PANE_STATES.EMPTY;
+  return PANE_STATES.DATA;
+}
+
+function selectThread(currentState, nextThreadId) {
+  const previousThreadId = currentState?.selectedThreadId ?? null;
+  const hasChanged = previousThreadId !== nextThreadId;
+
+  return {
+    selectedThreadId: nextThreadId,
+    tasksPane: {
+      sourceOfTruth: 'threads.selectedThreadId',
+      threadId: nextThreadId,
+      shouldRefresh: hasChanged,
+      updateOrder: ['threads.selectedThreadId', 'tasks.loading', 'tasks.fetch', 'tasks.render']
+    }
+  };
+}
+
+function isTreasuryTransitionAllowed(fromState, toState) {
+  if (!TREASURY_STATES.includes(fromState) || !TREASURY_STATES.includes(toState)) {
+    return false;
+  }
+  return ALLOWED_TREASURY_TRANSITIONS[fromState].includes(toState);
+}
+
+module.exports = {
+  PANE_STATES,
+  TREASURY_STATES,
+  ALLOWED_TREASURY_TRANSITIONS,
+  resolvePaneState,
+  selectThread,
+  isTreasuryTransitionAllowed
+};

--- a/apps/web/tests/pane-contract.test.js
+++ b/apps/web/tests/pane-contract.test.js
@@ -1,0 +1,39 @@
+const assert = require('node:assert/strict');
+const {
+  PANE_STATES,
+  resolvePaneState,
+  selectThread,
+  isTreasuryTransitionAllowed
+} = require('../paneContract');
+
+function run() {
+  // Pane state machine coverage
+  assert.equal(resolvePaneState({ loading: true, items: [] }), PANE_STATES.LOADING);
+  assert.equal(resolvePaneState({ error: 'timeout', items: [] }), PANE_STATES.ERROR);
+  assert.equal(resolvePaneState({ items: [] }), PANE_STATES.EMPTY);
+  assert.equal(resolvePaneState({ items: [{ id: 1 }] }), PANE_STATES.DATA);
+
+  // Selection propagation boundary + update order
+  const propagated = selectThread({ selectedThreadId: 'thread-63' }, 'thread-64');
+  assert.equal(propagated.selectedThreadId, 'thread-64');
+  assert.equal(propagated.tasksPane.sourceOfTruth, 'threads.selectedThreadId');
+  assert.equal(propagated.tasksPane.threadId, 'thread-64');
+  assert.equal(propagated.tasksPane.shouldRefresh, true);
+  assert.deepEqual(propagated.tasksPane.updateOrder, [
+    'threads.selectedThreadId',
+    'tasks.loading',
+    'tasks.fetch',
+    'tasks.render'
+  ]);
+
+  // Treasury transition constraints
+  assert.equal(isTreasuryTransitionAllowed('submitted', 'under_review'), true);
+  assert.equal(isTreasuryTransitionAllowed('under_review', 'approved'), true);
+  assert.equal(isTreasuryTransitionAllowed('approved', 'executed'), true);
+  assert.equal(isTreasuryTransitionAllowed('submitted', 'executed'), false);
+  assert.equal(isTreasuryTransitionAllowed('executed', 'under_review'), false);
+
+  console.log('[pane-contract][pass] interaction contract checks passed');
+}
+
+run();

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Provide one navigation hub for product, governance, operations, and contribution
 - pilot 14-day success plan v1: `docs/product/PILOT_14_DAY_SUCCESS_PLAN_V1.md`
 - pilot scorecard template v1: `docs/product/PILOT_SCORECARD_TEMPLATE_V1.md`
 - issue/pr sync api contract v1: `docs/product/ISSUE_PR_SYNC_API_V1.md`
+- cockpit interaction contract v1.2: `docs/product/COCKPIT_INTERACTION_CONTRACT_V1_1.md`
 
 ## governance docs
 - governance policy v1: `docs/governance/GOVERNANCE_V1.md`

--- a/docs/product/COCKPIT_INTERACTION_CONTRACT_V1_1.md
+++ b/docs/product/COCKPIT_INTERACTION_CONTRACT_V1_1.md
@@ -1,53 +1,89 @@
-# cockpit interaction contract v1.1
+# cockpit interaction contract v1.2
 
 ## metadata
-- version: v1.1.0
+- version: v1.2.0
 - owner_role: agent_product_governance
 - review_cadence: biweekly
 - next_review_due: 2026-03-23
 
 ## objective
-Define deterministic pane interaction behavior for the v1 cockpit so UI state and user actions are predictable.
+Freeze deterministic three-pane behavior for v1 so implementation and validation stay aligned.
 
 ## panes in scope
 - threads pane
 - tasks pane
 - treasury pane
 
-## state model (all panes)
-Each pane MUST resolve into one of:
+## canonical pane state machine
+All panes MUST resolve into one of:
 - `loading`
 - `data`
 - `empty`
 - `error`
 
-Transitions:
-- initial load -> `loading`
-- API success with rows -> `data`
-- API success with zero rows -> `empty`
-- API failure/timeout -> `error`
+State resolution order (highest priority first):
+1. `loading` when request in-flight
+2. `error` when request failed/timed out
+3. `empty` when request succeeds with zero rows
+4. `data` when request succeeds with >=1 row
 
-## interaction contract
+## selection propagation boundary (source of truth + update order)
+Source of truth:
+- `threads.selectedThreadId` is the only canonical selector for tasks-pane context.
+
+Required update order when a thread is selected:
+1. update `threads.selectedThreadId`
+2. set tasks pane state to `loading`
+3. fetch `GET /v1/threads/:thread_id/tasks` using selected id
+4. render tasks pane into `data|empty|error`
+
+Constraints:
+- tasks pane MUST NOT fetch against stale/unselected thread ids
+- tasks pane MUST re-render only from current selected thread context
+
+## pane-specific behavior
 ### threads pane
-- row click opens source URL in new tab
-- sort default: `updated_at desc`
-- filter v1: none
+- selecting a row updates `threads.selectedThreadId`
+- selected row remains visibly active until next explicit selection
 
 ### tasks pane
-- row click opens issue URL in new tab
-- sort default: `updated_at desc`
-- filter v1: state = open only
+- MUST derive context from `threads.selectedThreadId`
+- stale banner shown when thread response includes `thread.stale=true`
+- empty state shown when `items.length === 0`
 
 ### treasury pane
-- v1 placeholder allowed
-- if placeholder, MUST still honor state model
+Treasury states are fixed in v1:
+- `submitted`
+- `under_review`
+- `approved`
+- `executed`
+- `failed`
 
-## error behavior
-- display concise error message
-- surface retry action
-- do not show stale hardcoded content as primary path
+Allowed transitions only:
+- `submitted -> under_review | failed`
+- `under_review -> approved | failed`
+- `approved -> executed | failed`
+- `executed` terminal
+- `failed` terminal
 
-## validation
-- verify each pane traverses loading -> data
-- verify API-down forces error state
-- verify zero-row payload forces empty state
+Disallowed examples:
+- `submitted -> executed`
+- `executed -> under_review`
+
+## executable contract checks (light integration)
+Reference executable checks:
+- `apps/web/tests/pane-contract.test.js`
+
+Validated in checks:
+- pane state machine ordering
+- selection propagation source-of-truth + update order
+- treasury transition constraints
+
+## version bump rule (mandatory)
+Any contract behavior change MUST include:
+1. metadata `version` bump in this document
+2. corresponding update in executable contract checks
+3. PR note summarizing behavior delta and rollback path
+
+## rollback note
+If a contract change is unstable, revert to previous tagged contract version and restore matching executable checks in the same revert PR.


### PR DESCRIPTION
Closes #64

## scope (lane)
- Primary lane: `docs/product` + `apps/web` contract checks
- Upgraded cockpit contract doc with explicit v1.2 behavior freeze:
  - selection propagation boundary (source of truth + update order)
  - canonical pane state machine (`loading|data|empty|error`)
  - treasury mapping semantics and allowed transition constraints
  - mandatory contract-version bump rule for behavior changes
- Added lightweight executable contract checks:
  - `apps/web/paneContract.js`
  - `apps/web/tests/pane-contract.test.js`
- Added web package script:
  - `npm run test:contract`

## risk (blast radius)
- Low: docs + non-runtime testable contract module only.
- No deploy/infra/runtime API behavior changed in this PR.

## validation
- `bash scripts/docs/check_docs.sh`
- `GH_TOKEN=$(gh auth token) GITHUB_REPOSITORY=BoilerHAUS/moltch bash scripts/docs/check_docs.sh`
- `node --check apps/web/paneContract.js`
- `node apps/web/tests/pane-contract.test.js`

## rollback
- Revert this PR commit to restore previous contract wording and remove executable checks.
