### PR TITLE
docs: add deferred v2/web3 layer roadmap section (issue #84)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # architecture (v1)
 
 ## metadata
-- version: v1.0.1
+- version: v1.0.2
 - owner_role: agent_technical_delivery
 - review_cadence: biweekly
 - next_review_due: 2026-03-22
@@ -28,6 +28,7 @@ Provide a control plane where human and agent actors coordinate work and governe
 - explicit approval thresholds for treasury actions
 - tamper-evident audit records
 - no silent side effects
+- on-chain enforcement is the target state for A2/A3 policy evaluation; the `policy-engine` interface is the designated seam
 
 ## validation focus
 - every side effect has a linked decision record

--- a/docs/product/ROADMAP_V1.md
+++ b/docs/product/ROADMAP_V1.md
@@ -1,7 +1,7 @@
 # roadmap v1 (now -> v1 launch -> v1.1)
 
 ## metadata
-- version: v1.1.0
+- version: v1.2.0
 - owner_role: agent_product_governance
 - review_cadence: weekly
 - next_review_due: 2026-03-16
@@ -48,12 +48,24 @@ Allowed statuses:
 - #72 dashboard analytics view from commercial tracker
 - #75 release-note/changelog cadence
 - #77 policy/doc lifecycle refinement from weekly decision deltas
+
+### v2 / web3 layer (deferred post-v1 launch)
+- [ ] packages/contracts — on-chain implementation of policy-engine interface
+- [ ] packages/audit-log dual-write — emit decision log entries as on-chain events
+- [ ] Agent identity layer — signing keys / attestations for agent actors
+- [ ] Oracle bridge — off-chain executor requests on-chain approval, reports result
+- [ ] AI Contract Factory — generalized contract templates for agent interaction covenants
+
+v2 sequencing principle:
+- Promote cross-agent covenant rules to contract-level invariants first; implement auxiliary policy logic second.
+
+Tracking anchors:
 - #83 stable policy-engine interface for future on-chain implementation
 - #84 on-chain policy enforcement + audit log (deferred)
 - #86 v0 smart-contract spec pack + audit checklist
 
 ### defer rationale
-v1.1 items are deferred to protect v1 launch reliability and avoid coupling launch gate to analytics/process refinements.
+v1.1 and v2/web3 items are deferred to protect v1 launch reliability and avoid coupling launch gate to analytics/process refinements or on-chain implementation risk.
 
 ## open issues mapping (canonical)
 | issue | lane/phase | status | owner | dependency | target_window | last_updated | unblock_ask |
@@ -71,9 +83,9 @@ v1.1 items are deferred to protect v1 launch reliability and avoid coupling laun
 | #76 | program mgmt | in_progress | boilermolt | none | v1 | 2026-03-09 | n/a |
 | #77 | phase C | planned | boilermolt | #75 | v1.1 | 2026-03-09 | n/a |
 | #80 | program mgmt | planned | boilerclaw | #76 | v1 | 2026-03-09 | n/a |
-| #83 | phase C | planned | shared | #67 | v1.1 | 2026-03-12 | n/a |
-| #84 | phase C | planned | shared | #83 | v1.1 | 2026-03-12 | n/a |
-| #86 | phase C | planned | shared | #83, #84 | v1.1 | 2026-03-12 | n/a |
+| #83 | v2 / web3 | planned | shared | #67 | v2 | 2026-03-12 | n/a |
+| #84 | v2 / web3 | planned | shared | #83 | v2 | 2026-03-12 | n/a |
+| #86 | v2 / web3 | planned | shared | #83, #84 | v2 | 2026-03-12 | n/a |
 
 ## definition of done (roadmap update)
 A roadmap update is done only when all are true:


### PR DESCRIPTION
Closes #84

## scope
Docs-only update for deferred web3 planning and architecture seam documentation.

## changes
- `docs/product/ROADMAP_V1.md`
  - Added new `v2 / web3 layer (deferred post-v1 launch)` section
  - Added requested deferred checklist items:
    - packages/contracts on-chain policy-engine implementation
    - packages/audit-log dual-write via on-chain events
    - agent identity signing/attestation layer
    - oracle bridge for approval/execution reporting
    - AI contract factory templates for agent covenants
  - Added sequencing principle from issue discussion (covenant invariants first)
  - Kept #83/#84/#86 as tracking anchors and mapped them to `v2 / web3`
- `docs/ARCHITECTURE.md`
  - Added security baseline seam note:
    - On-chain enforcement is target state for A2/A3 policy evaluation
    - `policy-engine` interface is designated seam

## validation
- `bash scripts/docs/check_docs.sh`

## risk
- Low: documentation only, no implementation/runtime changes.

## rollback
- Revert this PR commit to restore prior roadmap/architecture wording.
