### PR TITLE
ops: add readiness evidence artifact writer contract (#97)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ Provide one navigation hub for product, governance, operations, and contribution
 - policy/doc lifecycle refinement v1: `docs/operations/POLICY_DOC_LIFECYCLE_REFINEMENT_V1.md`
 - launch-gate demos evidence (2026-03): `docs/operations/LAUNCH_GATE_DEMOS_ISSUE_PR_STATUS_2026-03.md`
 - readiness evidence bundle (2026-03-11): `docs/operations/evidence/readiness/2026-03-11/readiness_24h_summary.md`
+- readiness evidence writer dry-run sample (2026-03-14): `docs/operations/evidence/readiness/2026-03-14-dry-run/readiness_evidence_summary.md`
 - staging deploy baseline: `docs/operations/DEPLOY_STAGING.md`
 - staging edge + TLS: `docs/operations/STAGING_EDGE_TLS.md`
 - staging image versioning: `docs/operations/STAGING_IMAGE_VERSIONING.md`

--- a/docs/operations/RUNBOOK_V1.md
+++ b/docs/operations/RUNBOOK_V1.md
@@ -43,21 +43,36 @@ Use `docs/governance/POLICY_DECISION_REASON_CODE_CATALOG_V1_2.md` when recording
 ## readiness SLO evidence runner (24h launch gate)
 Target: 24h readiness success >= 99% with auditable artifact output.
 
-### live run command
+### step 1: collect probe data
+Live run command:
 `python3 scripts/ops/readiness_slo_runner.py --mode live --url http://localhost:8080/healthz --probes 288 --interval-seconds 300 --out-dir docs/operations/evidence/readiness/<YYYY-MM-DD>`
 
-### replay command (format validation)
+Replay command (format validation):
 `python3 scripts/ops/readiness_slo_runner.py --mode replay --url http://localhost:8080/healthz --out-dir docs/operations/evidence/readiness/<YYYY-MM-DD>`
 
+### step 2: write launch-gate evidence artifacts
+`python3 scripts/ops/readiness_artifact_writer.py --source-csv docs/operations/evidence/readiness/<YYYY-MM-DD>/readiness_24h.csv --out-dir docs/operations/evidence/readiness/<YYYY-MM-DD> --window-hours 24 --threshold-pct 99`
+
 ### expected outputs
+Probe runner:
 - `readiness_24h.csv`
 - `readiness_24h_summary.json`
 - `readiness_24h_summary.md`
 
+Artifact writer:
+- `readiness_evidence_summary.json`
+- `readiness_evidence_summary.md`
+
+### artifact interpretation
+- `overall_verdict=pass` means observed readiness success meets/exceeds threshold.
+- `overall_verdict=fail` means launch gate fails closed and promotion must stop.
+- `failure_slices` identifies grouped failure patterns by `status_code` and `error`.
+
 ### failure mode + escalation/rollback
-- if success_pct < 99: mark launch gate **fail**, do not promote.
+- if readiness writer cannot find required source CSV, exit non-zero (fail-closed).
+- if success_pct < threshold, mark launch gate **fail**, do not promote.
 - rollback: pin to last known-good deploy image and rerun readiness window.
-- escalation: post `needs-human` with failure slices (status_code/error grouped) and mitigation options.
+- escalation: post `needs-human` with failure slices and mitigation options.
 
 ## review artifacts
 - weekly scoreboard snapshot

--- a/docs/operations/evidence/readiness/2026-03-14-dry-run/readiness_evidence_summary.json
+++ b/docs/operations/evidence/readiness/2026-03-14-dry-run/readiness_evidence_summary.json
@@ -1,0 +1,24 @@
+{
+  "generated_at_utc": "2026-03-14T01:04:41+00:00",
+  "window_hours": 24,
+  "probe_count": 288,
+  "success_count": 286,
+  "failure_count": 2,
+  "metrics": [
+    {
+      "metric": "readiness_success_pct",
+      "window_hours": 24,
+      "threshold_pct": 99.0,
+      "observed_pct": 99.306,
+      "verdict": "pass"
+    }
+  ],
+  "failure_slices": [
+    {
+      "status_code": "503",
+      "error": "simulated_failure",
+      "count": 2
+    }
+  ],
+  "overall_verdict": "pass"
+}

--- a/docs/operations/evidence/readiness/2026-03-14-dry-run/readiness_evidence_summary.md
+++ b/docs/operations/evidence/readiness/2026-03-14-dry-run/readiness_evidence_summary.md
@@ -1,0 +1,15 @@
+# readiness evidence summary
+
+- generated_at_utc: 2026-03-14T01:04:41+00:00
+- source_csv: docs/operations/evidence/readiness/2026-03-11/readiness_24h.csv
+- window_hours: 24
+- probe_count: 288
+- success_count: 286
+- failure_count: 2
+- overall_verdict: **pass**
+
+## threshold evaluation
+- readiness_success_pct: observed `99.306%` vs threshold `99.0%` -> **pass**
+
+## failure slices
+- status_code=503 error=simulated_failure count=2

--- a/scripts/ops/readiness_artifact_writer.py
+++ b/scripts/ops/readiness_artifact_writer.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+
+def iso_now():
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def read_rows(csv_path: str):
+    if not os.path.exists(csv_path):
+        raise FileNotFoundError(f"required data source missing: {csv_path}")
+
+    rows = []
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        required_cols = {"index", "timestamp_utc", "ok", "status_code", "error"}
+        missing = required_cols - set(reader.fieldnames or [])
+        if missing:
+            raise ValueError(f"required columns missing in source csv: {sorted(missing)}")
+
+        for row in reader:
+            ok_raw = str(row.get("ok", "")).strip().lower()
+            ok = ok_raw in ("true", "1", "yes", "y")
+            rows.append(
+                {
+                    "index": int(row.get("index", 0)),
+                    "timestamp_utc": row.get("timestamp_utc"),
+                    "ok": ok,
+                    "status_code": row.get("status_code"),
+                    "error": row.get("error"),
+                }
+            )
+
+    if not rows:
+        raise ValueError("required data source is empty: no probe rows found")
+    return rows
+
+
+def summarize(rows, threshold_pct: float, window_hours: int):
+    total = len(rows)
+    success_count = sum(1 for r in rows if r["ok"])
+    failure_count = total - success_count
+    success_pct = round((success_count / total) * 100, 3)
+
+    status_error_counts = {}
+    for r in rows:
+        if r["ok"]:
+            continue
+        key = f"{r.get('status_code') or 'none'}|{r.get('error') or 'none'}"
+        status_error_counts[key] = status_error_counts.get(key, 0) + 1
+
+    failure_slices = [
+        {
+            "status_code": k.split("|", 1)[0],
+            "error": k.split("|", 1)[1],
+            "count": v,
+        }
+        for k, v in sorted(status_error_counts.items(), key=lambda kv: kv[1], reverse=True)
+    ]
+
+    metric_eval = {
+        "metric": "readiness_success_pct",
+        "window_hours": window_hours,
+        "threshold_pct": threshold_pct,
+        "observed_pct": success_pct,
+        "verdict": "pass" if success_pct >= threshold_pct else "fail",
+    }
+
+    overall_verdict = metric_eval["verdict"]
+
+    return {
+        "generated_at_utc": iso_now(),
+        "window_hours": window_hours,
+        "probe_count": total,
+        "success_count": success_count,
+        "failure_count": failure_count,
+        "metrics": [metric_eval],
+        "failure_slices": failure_slices,
+        "overall_verdict": overall_verdict,
+    }
+
+
+def write_json(path: str, payload: dict):
+    with open(path, "w") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
+
+
+def write_markdown(path: str, payload: dict, source_csv: str):
+    metric = payload["metrics"][0]
+    with open(path, "w") as f:
+        f.write("# readiness evidence summary\n\n")
+        f.write(f"- generated_at_utc: {payload['generated_at_utc']}\n")
+        f.write(f"- source_csv: {source_csv}\n")
+        f.write(f"- window_hours: {payload['window_hours']}\n")
+        f.write(f"- probe_count: {payload['probe_count']}\n")
+        f.write(f"- success_count: {payload['success_count']}\n")
+        f.write(f"- failure_count: {payload['failure_count']}\n")
+        f.write(f"- overall_verdict: **{payload['overall_verdict']}**\n\n")
+
+        f.write("## threshold evaluation\n")
+        f.write(
+            f"- readiness_success_pct: observed `{metric['observed_pct']}%` vs threshold `{metric['threshold_pct']}%` -> **{metric['verdict']}**\n\n"
+        )
+
+        f.write("## failure slices\n")
+        if not payload["failure_slices"]:
+            f.write("- none\n")
+        else:
+            for item in payload["failure_slices"]:
+                f.write(
+                    f"- status_code={item['status_code']} error={item['error']} count={item['count']}\n"
+                )
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--source-csv", required=True)
+    p.add_argument("--out-dir", required=True)
+    p.add_argument("--window-hours", type=int, default=24)
+    p.add_argument("--threshold-pct", type=float, default=99.0)
+    args = p.parse_args()
+
+    try:
+        rows = read_rows(args.source_csv)
+        payload = summarize(rows, args.threshold_pct, args.window_hours)
+    except Exception as e:
+        print(f"[readiness-writer][fail] {e}", file=sys.stderr)
+        sys.exit(1)
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    json_path = os.path.join(args.out_dir, "readiness_evidence_summary.json")
+    md_path = os.path.join(args.out_dir, "readiness_evidence_summary.md")
+
+    write_json(json_path, payload)
+    write_markdown(md_path, payload, args.source_csv)
+
+    print(f"[readiness-writer][pass] wrote {json_path}")
+    print(f"[readiness-writer][pass] wrote {md_path}")
+
+    if payload["overall_verdict"] != "pass":
+        print("[readiness-writer][fail] threshold not met (fail-closed)", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/ops/readiness_artifact_writer.py` to generate deterministic launch-gate artifacts from a required readiness CSV data source
- writer now emits both machine-readable and human-readable outputs:
  - `readiness_evidence_summary.json`
  - `readiness_evidence_summary.md`
- include explicit threshold evaluation (target vs observed) and top-level verdict (`pass`/`fail`)
- fail closed when required data source is missing/invalid or when threshold is not met
- update runbook with invocation + interpretation flow for probe collection + artifact writing
- commit dry-run example artifacts for review under `docs/operations/evidence/readiness/2026-03-14-dry-run/`

## Acceptance Criteria Mapping (#97)
- [x] Script writes JSON + markdown artifacts for a run
- [x] Output includes timestamp, metric windows, thresholds, and verdict
- [x] Fails closed when required data source is missing
- [x] Runbook entry documents invocation + artifact interpretation
- [x] Dry-run example artifact committed for review

## Validation
```bash
python3 scripts/ops/readiness_artifact_writer.py \
  --source-csv docs/operations/evidence/readiness/2026-03-11/readiness_24h.csv \
  --out-dir docs/operations/evidence/readiness/2026-03-14-dry-run \
  --window-hours 24 \
  --threshold-pct 99

bash scripts/docs/check_docs.sh
```

Refs #97
