### PR TITLE
ops: add source_csv provenance to readiness JSON output

### DIFF
--- a/docs/operations/evidence/readiness/2026-03-14-dry-run/readiness_evidence_summary.json
+++ b/docs/operations/evidence/readiness/2026-03-14-dry-run/readiness_evidence_summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-03-14T01:04:41+00:00",
+  "generated_at_utc": "2026-03-14T01:16:12+00:00",
   "window_hours": 24,
   "probe_count": 288,
   "success_count": 286,
@@ -20,5 +20,6 @@
       "count": 2
     }
   ],
-  "overall_verdict": "pass"
+  "overall_verdict": "pass",
+  "source_csv": "docs/operations/evidence/readiness/2026-03-11/readiness_24h.csv"
 }

--- a/docs/operations/evidence/readiness/2026-03-14-dry-run/readiness_evidence_summary.md
+++ b/docs/operations/evidence/readiness/2026-03-14-dry-run/readiness_evidence_summary.md
@@ -1,6 +1,6 @@
 # readiness evidence summary
 
-- generated_at_utc: 2026-03-14T01:04:41+00:00
+- generated_at_utc: 2026-03-14T01:16:12+00:00
 - source_csv: docs/operations/evidence/readiness/2026-03-11/readiness_24h.csv
 - window_hours: 24
 - probe_count: 288

--- a/scripts/ops/readiness_artifact_writer.py
+++ b/scripts/ops/readiness_artifact_writer.py
@@ -129,6 +129,7 @@ def main():
     try:
         rows = read_rows(args.source_csv)
         payload = summarize(rows, args.threshold_pct, args.window_hours)
+        payload["source_csv"] = args.source_csv
     except Exception as e:
         print(f"[readiness-writer][fail] {e}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## Summary
Tiny follow-up to PR #110 reviewer suggestion:
- add `source_csv` to JSON payload in `scripts/ops/readiness_artifact_writer.py`
- regenerate dry-run sample artifacts to reflect new provenance field

## Why
Keeps provenance symmetry between markdown and JSON outputs, improving machine-side audit joins.

## Validation
- `python3 scripts/ops/readiness_artifact_writer.py --source-csv docs/operations/evidence/readiness/2026-03-11/readiness_24h.csv --out-dir docs/operations/evidence/readiness/2026-03-14-dry-run --window-hours 24 --threshold-pct 99`
- `bash scripts/docs/check_docs.sh`

Stacked follow-up to #110.
