### PR TITLE
docs: deliver launch-gate demo 1 evidence bundle (#98)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ Provide one navigation hub for product, governance, operations, and contribution
 - launch-gate demos evidence (2026-03): `docs/operations/LAUNCH_GATE_DEMOS_ISSUE_PR_STATUS_2026-03.md`
 - readiness evidence bundle (2026-03-11): `docs/operations/evidence/readiness/2026-03-11/readiness_24h_summary.md`
 - readiness evidence writer dry-run sample (2026-03-14): `docs/operations/evidence/readiness/2026-03-14-dry-run/readiness_evidence_summary.md`
+- launch-gate demo 1 evidence package (2026-03-14): `docs/operations/evidence/LAUNCH_GATE_DEMO1_EVIDENCE_PACKAGE_2026-03-14.md`
 - staging deploy baseline: `docs/operations/DEPLOY_STAGING.md`
 - staging edge + TLS: `docs/operations/STAGING_EDGE_TLS.md`
 - staging image versioning: `docs/operations/STAGING_IMAGE_VERSIONING.md`

--- a/docs/operations/evidence/LAUNCH_GATE_DEMO1_EVIDENCE_PACKAGE_2026-03-14.md
+++ b/docs/operations/evidence/LAUNCH_GATE_DEMO1_EVIDENCE_PACKAGE_2026-03-14.md
@@ -1,0 +1,49 @@
+# launch-gate demo 1 evidence package (2026-03-14)
+
+## metadata
+- version: v1.0.0
+- owner_role: agent_technical_delivery
+- review_cadence: one-off launch-gate artifact
+- next_review_due: n/a
+
+## objective
+Execute one complete issue -> PR -> status reflection path with auditable evidence for launch-gate demo requirements in #70.
+
+## scope refs
+- source issue: https://github.com/BoilerHAUS/moltch/issues/98
+- parent launch-gate issue: https://github.com/BoilerHAUS/moltch/issues/70
+
+## path executed
+1. Opened execution issue slice (#98) with demo AC.
+2. Delivered implementation PR for evidence schema:
+   - https://github.com/BoilerHAUS/moltch/pull/109
+3. Reflected status in issue/PR comments (traceability + mergeability updates):
+   - conflict resolution update: https://github.com/BoilerHAUS/moltch/pull/109#issuecomment-4059058518
+   - issue planning/status checkpoint: https://github.com/BoilerHAUS/moltch/issues/98#issuecomment-4059071789
+4. Captured bundle against standardized schema introduced by #96.
+
+## traceability
+- issue: https://github.com/BoilerHAUS/moltch/issues/98
+- implementation PR: https://github.com/BoilerHAUS/moltch/pull/109
+- merged commit SHA: `fd1710fa3282c1c50d77cb3118fd374d2e2f5fcf`
+- required checks snapshot (PR #109):
+  - repo-baseline: pass
+  - docs checks: pass
+
+## reflected status proof
+- project decision/status reflection recorded in issue comments and PR thread:
+  - https://github.com/BoilerHAUS/moltch/issues/98#issuecomment-4059071789
+  - https://github.com/BoilerHAUS/moltch/pull/109#issuecomment-4059058518
+
+## edge-case note encountered
+- During PR #109 update, merge conflict occurred in `docs/operations/RUNBOOK_V1.md` after upstream changes.
+- Resolution path was executed and documented in PR comments; conflict cleared and PR returned to mergeable state.
+
+## pass/fail summary against #70 demo criteria
+- Evidence bundle attached/linked: **pass**
+- Includes issue/PR/check/status reflection links: **pass**
+- Includes edge-case note: **pass**
+- Ends with explicit pass/fail summary: **pass**
+
+## final verdict
+**pass** — Demo 1 objective satisfied with auditable traceability and status reflection evidence.


### PR DESCRIPTION
## Summary
- add Demo 1 launch-gate evidence bundle under `docs/operations/evidence/`
- document full issue -> PR -> status-reflection path for #98
- include traceability to issue, PR, merge SHA, and reflected status links
- include edge-case note and explicit pass/fail summary against #70 criteria
- index artifact in `docs/README.md`

## Acceptance Criteria Mapping (#98)
- [x] Evidence bundle attached/linked using standard schema/template
- [x] Includes links to issue, PR, checks, and reflected status proof
- [x] Includes at least one edge-case note encountered during flow
- [x] Ends with pass/fail summary against #70 criteria

## Validation
```bash
bash scripts/docs/check_docs.sh
```

Closes #98
