### PR TITLE
docs: add pilot loop decision outcome memo artifact (#100)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Provide one navigation hub for product, governance, operations, and contribution
 - commercial analytics dashboard spec v1: `docs/product/COMMERCIAL_ANALYTICS_DASHBOARD_SPEC_V1.md`
 - pilot offer packaging v1.1: `docs/product/PILOT_OFFER_PACKAGING_V1_1.md`
 - pilot commercial loop evidence package v1: `docs/product/PILOT_COMMERCIAL_LOOP_EVIDENCE_PACKAGE_V1.md`
+- pilot commercial loop decision memo (2026-03-14): `docs/product/PILOT_COMMERCIAL_LOOP_DECISION_MEMO_2026-03-14.md`
 - roadmap v1: `docs/product/ROADMAP_V1.md`
 - claude session operating prompt v0.2: `docs/product/CLAUDE_SESSION_OPERATING_PROMPT_V0_2.md`
 

--- a/docs/product/PILOT_COMMERCIAL_LOOP_DECISION_MEMO_2026-03-14.md
+++ b/docs/product/PILOT_COMMERCIAL_LOOP_DECISION_MEMO_2026-03-14.md
@@ -1,0 +1,51 @@
+# pilot commercial loop decision memo (2026-03-14)
+
+## metadata
+- version: v1.0.0
+- owner_role: agent_product_governance
+- review_cadence: one-off launch-gate memo
+- next_review_due: n/a
+
+## objective
+Provide a decision-ready pilot loop closeout memo for issue #100 and issue #68 launch-readiness evidence consumption.
+
+## scope references
+- issue #100: https://github.com/BoilerHAUS/moltch/issues/100
+- issue #68: https://github.com/BoilerHAUS/moltch/issues/68
+
+## success criteria (pilot closeout)
+1. Evidence package exists and is linked.
+2. Launch-gate demo paths are complete and auditable.
+3. Readiness evidence artifact path is deterministic and fail-closed.
+4. A clear next-action decision is documented.
+
+## observed outcomes
+- Pilot commercial loop evidence package is documented:
+  - `docs/product/PILOT_COMMERCIAL_LOOP_EVIDENCE_PACKAGE_V1.md`
+- Launch-gate demos completed with explicit artifacts:
+  - Demo 1 evidence: `docs/operations/evidence/LAUNCH_GATE_DEMO1_EVIDENCE_PACKAGE_2026-03-14.md`
+  - Demo 2 edge evidence: `docs/operations/evidence/LAUNCH_GATE_DEMO2_EDGE_EVIDENCE_PACKAGE_2026-03-14.md`
+- Readiness artifact writer implementation and provenance follow-up merged in PR flow:
+  - https://github.com/BoilerHAUS/moltch/pull/110
+  - https://github.com/BoilerHAUS/moltch/pull/111
+- Launch-gate evidence schema standardized:
+  - `docs/operations/LAUNCH_GATE_EVIDENCE_PACKAGE_SCHEMA_V1.md`
+
+## evidence links
+- pilot loop evidence pack PR: https://github.com/BoilerHAUS/moltch/pull/103
+- launch-gate schema PR: https://github.com/BoilerHAUS/moltch/pull/109
+- demo 1 PR: https://github.com/BoilerHAUS/moltch/pull/112
+- demo 2 PR: https://github.com/BoilerHAUS/moltch/pull/113
+- readiness artifact writer PRs: https://github.com/BoilerHAUS/moltch/pull/110, https://github.com/BoilerHAUS/moltch/pull/111
+
+## decision statement (go/no-go)
+**go (controlled)** for completing v1 launch-gate closeout based on available demo/readiness evidence quality.
+
+## rationale
+- Required evidence surfaces now exist in deterministic, reviewable form.
+- Edge-condition handling has been demonstrated and remediated with traceability.
+- Remaining risk is operational cadence consistency rather than missing artifact contract.
+
+## next action
+- Proceed to final launch-readiness review packet assembly and human signoff thread.
+- Keep rollout controlled until production-like runtime checks are repeated on latest merged main.


### PR DESCRIPTION
## Summary
- add pilot commercial loop decision memo artifact for launch-readiness closeout
- include objective, success criteria, observed outcomes, and linked evidence sources
- provide explicit go/no-go decision statement with rationale and next action
- index memo in `docs/README.md`

## Acceptance Criteria Mapping (#100)
- [x] Pilot memo doc added with metadata
- [x] References concrete evidence artifacts from execution
- [x] Contains explicit go/no-go style decision statement
- [x] Linked from docs index/runbook navigation path

## Validation
```bash
bash scripts/docs/check_docs.sh
```

Closes #100
