### PR TITLE
docs/ci: roadmap drift reconciliation + guardrail enforcement (#136)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,3 +25,4 @@
 - [ ] Issue-first flow followed
 - [ ] Branch from fork used
 - [ ] No direct push to protected default branch
+- [ ] Roadmap mapping updated (or excluded rationale added) when issues open/close/re-scope

--- a/docs/product/ROADMAP_V1.md
+++ b/docs/product/ROADMAP_V1.md
@@ -1,10 +1,10 @@
 # roadmap v1 (now -> v1 launch -> v1.1)
 
 ## metadata
-- version: v1.2.3
+- version: v1.2.4
 - owner_role: agent_product_governance
 - review_cadence: weekly
-- next_review_due: 2026-03-16
+- next_review_due: 2026-03-22
 
 ## objective
 Align execution around a sequenced path from baseline docs/scaffolds to v1 launch and immediate v1.1 upgrades.
@@ -70,40 +70,8 @@ v1.1 and v2/web3 items are deferred to protect v1 launch reliability and avoid c
 ## open issues mapping (canonical)
 | issue | lane/phase | status | owner | dependency | target_window | last_updated | unblock_ask |
 |---|---|---|---|---|---|---|---|
-| #63 | phase A | planned | boilerclaw | #64 | v1 | 2026-03-09 | n/a |
-| #64 | phase A | planned | shared | none | v1 | 2026-03-09 | n/a |
-| #65 | phase A | planned | boilerclaw | none | v1 | 2026-03-09 | n/a |
-| #66 | phase A | planned | boilermolt | none | v1 | 2026-03-09 | n/a |
-| #67 | phase B | planned | boilermolt | #66 | v1 | 2026-03-09 | n/a |
-| #68 | phase B | planned | boilermolt | #63, #64, #67 | v1 | 2026-03-09 | n/a |
-| #70 | launch gate | planned | shared | #63, #64 | v1 | 2026-03-09 | n/a |
-| #72 | phase C | planned | shared | #68 | v1.1 | 2026-03-09 | n/a |
-| #74 | launch gate | planned | boilerclaw | #65 | v1 | 2026-03-09 | n/a |
-| #75 | phase C | planned | boilermolt | #68 | v1.1 | 2026-03-09 | n/a |
-| #76 | program mgmt | in_progress | boilermolt | none | v1 | 2026-03-09 | n/a |
-| #77 | phase C | planned | boilermolt | #75 | v1.1 | 2026-03-09 | n/a |
-| #80 | program mgmt | planned | boilerclaw | #76 | v1 | 2026-03-09 | n/a |
-| #83 | v2 / web3 | planned | shared | #67 | v2 | 2026-03-12 | n/a |
-| #84 | v2 / web3 | planned | shared | #83 | v2 | 2026-03-12 | n/a |
-| #86 | v2 / web3 | planned | shared | #83, #84 | v2 | 2026-03-12 | n/a |
-| #96 | launch gate | planned | shared | #68, #70, #74 | v1 | 2026-03-12 | n/a |
-| #97 | launch gate | planned | boilerclaw | #74, #96 | v1 | 2026-03-12 | n/a |
-| #98 | launch gate | planned | shared | #70, #96 | v1 | 2026-03-12 | n/a |
-| #99 | launch gate | planned | shared | #70, #96, #98 | v1 | 2026-03-12 | n/a |
-| #100 | phase B | planned | boilermolt | #68, #96 | v1 | 2026-03-12 | n/a |
-| #116 | launch gate | in_progress | boilerclaw | #96 | v1 | 2026-03-14 | n/a |
-| #117 | launch gate | planned | boilerclaw | #116 | v1 | 2026-03-14 | n/a |
-| #118 | launch gate | planned | shared | #117 | v1 | 2026-03-14 | n/a |
-| #119 | governance hardening | planned | boilermolt | #67 | v1.1 | 2026-03-14 | n/a |
-| #120 | ops analytics | planned | shared | #117 | v1.1 | 2026-03-14 | n/a |
-| #122 | launch gate quality follow-up | planned | boilermolt | #116 | v1 | 2026-03-14 | n/a |
-| #123 | launch gate quality follow-up | planned | boilermolt | #122 | v1 | 2026-03-14 | n/a |
-| #124 | launch gate quality follow-up | planned | boilermolt | #122, #123 | v1 | 2026-03-14 | n/a |
-| #127 | launch gate quality follow-up | planned | boilermolt | #117, #122 | v1 | 2026-03-14 | n/a |
-| #134 | launch gate quality follow-up | planned | boilermolt | #122 | v1 | 2026-03-15 | n/a |
-| #135 | launch gate quality follow-up | planned | boilermolt | #134 | v1 | 2026-03-15 | n/a |
-| #136 | program mgmt | planned | boilermolt | #76 | v1 | 2026-03-15 | n/a |
-| #137 | ops control | planned | shared | #134, #135, #136 | v1 | 2026-03-15 | n/a |
+| #136 | program mgmt | in_progress | boilermolt | none | v1 | 2026-03-15 | n/a |
+| #137 | ops control | planned | shared | #136 | v1 | 2026-03-15 | n/a |
 
 ## definition of done (roadmap update)
 A roadmap update is done only when all are true:

--- a/scripts/docs/check_docs.sh
+++ b/scripts/docs/check_docs.sh
@@ -291,9 +291,14 @@ check_roadmap_issue_mapping() {
   export GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
 
   mapfile -t open_issue_nums < <(gh api --paginate -X GET "repos/${repo}/issues?state=open&per_page=100" --jq '.[] | select(.pull_request == null) | .number')
+  mapfile -t mapped_issue_nums < <(sed -nE 's/^\|[[:space:]]*#([0-9]+)[[:space:]]*\|.*/\1/p' "$roadmap")
 
-  declare -A mapped excluded
-  while IFS= read -r n; do mapped["$n"]=1; done < <(sed -nE 's/^\|[[:space:]]*#([0-9]+)[[:space:]]*\|.*/\1/p' "$roadmap")
+  declare -A open_set mapped excluded mapped_counts
+  for n in "${open_issue_nums[@]}"; do open_set["$n"]=1; done
+  for n in "${mapped_issue_nums[@]}"; do
+    mapped["$n"]=1
+    mapped_counts["$n"]=$(( ${mapped_counts["$n"]:-0} + 1 ))
+  done
   while IFS= read -r n; do excluded["$n"]=1; done < <(awk '
     BEGIN {in_ex=0}
     /^## excluded issues/ {in_ex=1; next}
@@ -301,10 +306,22 @@ check_roadmap_issue_mapping() {
     in_ex==1 {print}
   ' "$roadmap" | grep -oE '#[0-9]+' | tr -d '#' | sort -u)
 
-  local missing=() n
+  local missing=() closed_in_mapping=() duplicates=()
   for n in "${open_issue_nums[@]}"; do
     if [[ -z "${mapped[$n]:-}" && -z "${excluded[$n]:-}" ]]; then
       missing+=("#$n")
+    fi
+  done
+
+  for n in "${mapped_issue_nums[@]}"; do
+    if [[ -z "${open_set[$n]:-}" ]]; then
+      closed_in_mapping+=("#$n")
+    fi
+  done
+
+  for n in "${!mapped_counts[@]}"; do
+    if (( mapped_counts["$n"] > 1 )); then
+      duplicates+=("#$n")
     fi
   done
 
@@ -312,7 +329,15 @@ check_roadmap_issue_mapping() {
     fail "open issues missing roadmap mapping/exclusion: ${missing[*]}"
   fi
 
-  pass "roadmap mapping coverage ok (${#open_issue_nums[@]} open issues)"
+  if (( ${#closed_in_mapping[@]} > 0 )); then
+    fail "closed issues still listed in open issues mapping: ${closed_in_mapping[*]} (remove from mapping table or reopen issues)"
+  fi
+
+  if (( ${#duplicates[@]} > 0 )); then
+    fail "issues mapped more than once in open issues mapping: ${duplicates[*]}"
+  fi
+
+  pass "roadmap mapping coverage ok (${#open_issue_nums[@]} open issues, ${#mapped_issue_nums[@]} mapped rows)"
 }
 
 check_metadata_scope


### PR DESCRIPTION
## Summary
- reconcile `docs/product/ROADMAP_V1.md` open-issue mapping to current GitHub open issue set
- add fail-closed CI checks for roadmap drift (closed issues still mapped, duplicate mappings, and missing open mappings)
- add explicit roadmap-sync step to PR checklist for issue open/close/re-scope changes

## What changed
- roadmap cleanup pass:
  - bumped roadmap metadata version to `v1.2.4`
  - updated open issues mapping table to current open issues only (`#136`, `#137`)
  - normalized dependencies/status for active workstream continuity
- `scripts/docs/check_docs.sh` (`check_roadmap_issue_mapping`) now enforces:
  - every open issue is mapped or explicitly excluded
  - no closed issues remain in the "open issues mapping" table
  - no duplicate rows for the same issue in mapping table
- `.github/pull_request_template.md` checklist now includes roadmap mapping sync requirement

## Validation
- `bash scripts/docs/check_docs.sh`
- `GH_TOKEN=$(gh auth token) GITHUB_REPOSITORY=BoilerHAUS/moltch bash scripts/docs/check_docs.sh`

Closes #136
