### PR TITLE
ci: add dedicated launch-gate contract workflow (#142)

### DIFF
--- a/.github/workflows/launch-gate-contracts.yml
+++ b/.github/workflows/launch-gate-contracts.yml
@@ -1,0 +1,108 @@
+name: Launch Gate Contracts
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/ops/**'
+      - 'scripts/docs/**'
+      - 'docs/operations/**'
+      - 'docs/governance/**'
+      - '.github/workflows/launch-gate-contracts.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/ops/**'
+      - 'scripts/docs/**'
+      - 'docs/operations/**'
+      - 'docs/governance/**'
+      - '.github/workflows/launch-gate-contracts.yml'
+
+jobs:
+  launch-gate-contracts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Schema fixtures (positive + negative)
+        run: |
+          set -euo pipefail
+          schema="docs/operations/schemas/LAUNCH_GATE_EVIDENCE_PACKAGE_V1.schema.json"
+          validator="scripts/ops/validate_launch_gate_evidence.py"
+
+          python3 "$validator" --schema "$schema" \
+            --input docs/operations/evidence/launch_gate_evidence_package_valid_v1.json \
+            --input docs/operations/evidence/launch_gate_evidence_package_valid_edge_v1.json >/dev/null
+
+          for invalid in \
+            docs/operations/evidence/launch_gate_evidence_package_invalid_missing_required_v1.json \
+            docs/operations/evidence/launch_gate_evidence_package_invalid_enum_v1.json \
+            docs/operations/evidence/launch_gate_evidence_package_invalid_extra_root_v1.json \
+            docs/operations/evidence/launch_gate_evidence_package_invalid_extra_nested_v1.json \
+            docs/operations/evidence/launch_gate_evidence_package_invalid_extra_runtime_nested_v1.json \
+            docs/operations/evidence/launch_gate_evidence_package_invalid_format_v1.json \
+            docs/operations/evidence/launch_gate_evidence_package_invalid_pattern_v1.json \
+            docs/operations/evidence/launch_gate_evidence_package_invalid_composition_v1.json
+          do
+            if python3 "$validator" --schema "$schema" --input "$invalid" >/dev/null 2>&1; then
+              echo "[launch-gate-contracts][fail] invalid fixture unexpectedly passed: $invalid"
+              exit 1
+            fi
+          done
+
+      - name: Launch-readiness packet derivation checks
+        run: |
+          set -euo pipefail
+          builder="scripts/ops/build_launch_readiness_packet.py"
+          out_dir="docs/operations/evidence/launch-readiness/2026-03-14-dry-run"
+          fixed_sha="deterministic-sha-v1"
+
+          python3 "$builder" \
+            --manifest docs/operations/evidence/launch-readiness/launch_readiness_packet_manifest_v1.json \
+            --out-dir "$out_dir" \
+            --source-commit-sha "$fixed_sha" >/dev/null
+
+          decision=$(python3 -c 'import json;print(json.load(open("docs/operations/evidence/launch-readiness/2026-03-14-dry-run/launch_readiness_packet.json"))["decision"])')
+          test "$decision" = "go"
+
+          mkdir -p .tmp
+          hold_dir=$(mktemp -d .tmp/launch-packet-hold.XXXXXX)
+          python3 "$builder" \
+            --manifest docs/operations/evidence/launch-readiness/launch_readiness_packet_manifest_hold_v1.json \
+            --out-dir "$hold_dir" \
+            --source-commit-sha "$fixed_sha" >/dev/null
+          hold_decision=$(python3 -c "import json;print(json.load(open('$hold_dir/launch_readiness_packet.json'))['decision'])")
+          test "$hold_decision" = "hold"
+          rm -rf "$hold_dir"
+
+          if python3 "$builder" \
+            --manifest docs/operations/evidence/launch-readiness/launch_readiness_packet_manifest_invalid_v1.json \
+            --out-dir "$out_dir" >/dev/null 2>&1; then
+            echo "[launch-gate-contracts][fail] invalid launch-readiness manifest unexpectedly passed"
+            exit 1
+          fi
+
+      - name: Policy conformance fixtures (positive + negative)
+        run: |
+          set -euo pipefail
+          runner="scripts/ops/run_policy_decision_conformance.py"
+          catalog="docs/governance/POLICY_DECISION_REASON_CODE_CATALOG_V1_2.md"
+
+          python3 "$runner" \
+            --fixtures docs/governance/fixtures/policy_decision_conformance_cases_v1.json \
+            --catalog "$catalog" \
+            --out-json docs/governance/evidence/policy_decision_conformance_summary_2026-03-14.json \
+            --out-md docs/governance/evidence/POLICY_DECISION_CONFORMANCE_SUMMARY_2026-03-14.md \
+            --generated-at-utc "2026-03-14T00:00:00Z" >/dev/null
+
+          if python3 "$runner" \
+            --fixtures docs/governance/fixtures/policy_decision_conformance_cases_invalid_v1.json \
+            --catalog "$catalog" \
+            --out-json /tmp/policy_conformance_invalid.json \
+            --out-md /tmp/policy_conformance_invalid.md \
+            --generated-at-utc "2026-03-14T00:00:00Z" >/dev/null 2>&1; then
+            echo "[launch-gate-contracts][fail] invalid policy conformance fixture unexpectedly passed"
+            exit 1
+          fi

--- a/docs/operations/RUNBOOK_V1.md
+++ b/docs/operations/RUNBOOK_V1.md
@@ -130,6 +130,13 @@ Run policy decision conformance checks:
 ## launch signoff entrypoint
 - canonical evidence index: `docs/operations/evidence/LAUNCH_EVIDENCE_INDEX_2026-03.md`
 
+## launch-gate contract CI signal
+- workflow: `.github/workflows/launch-gate-contracts.yml` (check name: `launch-gate-contracts`)
+- triage order when it fails:
+  1) schema fixtures (`scripts/ops/validate_launch_gate_evidence.py`)
+  2) launch-readiness packet derivation (`scripts/ops/build_launch_readiness_packet.py`)
+  3) policy conformance fixtures (`scripts/ops/run_policy_decision_conformance.py`)
+
 ## review artifacts
 - weekly review-ops scoreboard spec: `docs/operations/REVIEW_OPS_SCOREBOARD_SPEC_V1.md`
 - weekly scoreboard snapshot (generated): `docs/operations/evidence/review-ops/2026-W11/review_ops_scoreboard.md`

--- a/docs/product/ROADMAP_V1.md
+++ b/docs/product/ROADMAP_V1.md
@@ -70,9 +70,8 @@ v1.1 and v2/web3 items are deferred to protect v1 launch reliability and avoid c
 ## open issues mapping (canonical)
 | issue | lane/phase | status | owner | dependency | target_window | last_updated | unblock_ask |
 |---|---|---|---|---|---|---|---|
-| #141 | program mgmt | planned | boilerclaw | none | v1 | 2026-03-15 | n/a |
-| #142 | phase A | planned | boilerclaw | #141 | v1 | 2026-03-15 | n/a |
-| #143 | phase B | planned | boilermolt | #141 | v1 | 2026-03-15 | n/a |
+| #142 | phase A | in_progress | boilerclaw | none | v1 | 2026-03-15 | n/a |
+| #143 | phase B | planned | boilermolt | #142 | v1 | 2026-03-15 | n/a |
 
 ## definition of done (roadmap update)
 A roadmap update is done only when all are true:


### PR DESCRIPTION
## Summary
- add a dedicated CI workflow for launch-gate contract checks
- keep existing `repo-baseline` gate intact (additive signal for faster triage)
- document failure triage order in runbook

## What changed
- new workflow: `.github/workflows/launch-gate-contracts.yml`
  - check name: `launch-gate-contracts`
  - validates three subsystems independently:
    1) launch-gate schema fixtures (positive + negative)
    2) launch-readiness packet derivation fixtures (`go`/`hold`/invalid)
    3) policy conformance fixtures (positive + negative)
- runbook update: added "launch-gate contract CI signal" section with triage order in `docs/operations/RUNBOOK_V1.md`
- roadmap mapping update: removed closed #141 and set active open-issue mapping for #142/#143

## Validation
- `bash scripts/docs/check_docs.sh`

Closes #142
